### PR TITLE
power: add sensor_ind to boeffla_wl_blocker && fix the value of LENGTH_LIST_WL_DEFAULT

### DIFF
--- a/drivers/base/power/boeffla_wl_blocker.h
+++ b/drivers/base/power/boeffla_wl_blocker.h
@@ -16,8 +16,8 @@
 
 #define BOEFFLA_WL_BLOCKER_VERSION	"1.1.0"
 
-#define LIST_WL_DEFAULT			"IPA_WS;NETLINK;netmgr_wl;qcom_rx_wakelock;[timerfd];wcnss_filter_lock;wlan;wlan_extscan_wl;wlan_ipa;wlan_pno_wl;wlan_wow_wl"
+#define LIST_WL_DEFAULT			"IPA_WS;NETLINK;netmgr_wl;qcom_rx_wakelock;[timerfd];wcnss_filter_lock;wlan;wlan_extscan_wl;wlan_ipa;wlan_pno_wl;wlan_wow_wl;sensor_ind"
 
 #define LENGTH_LIST_WL			255
-#define LENGTH_LIST_WL_DEFAULT		125
+#define LENGTH_LIST_WL_DEFAULT		134
 #define LENGTH_LIST_WL_SEARCH		LENGTH_LIST_WL + LENGTH_LIST_WL_DEFAULT + 5


### PR DESCRIPTION
this sensor_ind kernel wakelock sometimes keeps device awake after reboot in Oreo (maybe in pie too) and last for a long time, so add it to boeffla_wl_blocker's block list and it won't cause any problems.